### PR TITLE
Trying to disconnect without a valid WS is now displaying a warning

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -92,9 +92,12 @@ module.exports =
 
   deactivate: ->
     clearInterval(@heartbeatId)
-    atom.notifications.addSuccess("Motepair: Disconnected from session.")
-    @sessionStatusView?.hide()
-    @ws?.close()
-    @ws = null
-    @event_handler?.subscriptions.dispose()
-    @atom_share?.subscriptions.dispose()
+    if @ws?
+      atom.notifications.addSuccess("Motepair: Disconnected from session.")
+      @sessionStatusView.hide()
+      @ws.close()
+      @ws = null
+      @event_handler.subscriptions.dispose()
+      @atom_share.subscriptions.dispose()
+    else
+      atom.notifications.addWarning("Motepair: No active session found.")


### PR DESCRIPTION
Well....not really a big feature / fix (so i didn't created a branch for that), i just think disconnecting without having a valid connection should display something else than a green message :).

Anyway this will not be my only contribution...thanks a LOT for this awesome package, guys. I'll probably use it everyday.

Bonus question : because your server is independent from Atom, it would be possible to create plugins for any other editor, wouldn't it ?
