### PR TITLE
Gravatar on cursor

### DIFF
--- a/lib/event_handler.coffee
+++ b/lib/event_handler.coffee
@@ -12,6 +12,7 @@ class EventHandler
     @workspace = atom.workspace
     @subscriptions = new CompositeDisposable
     @localChange = false
+    @userEmail = atom.config.get('motepair.userEmail')
 
   onopen: (data) ->
     path = "#{@projectPath}/#{data.file}"
@@ -42,7 +43,7 @@ class EventHandler
     return unless editor? and editor.markBufferPosition?
     editor.remoteCursor?.marker.destroy()
 
-    editor.remoteCursor = new RemoteCursorView(editor, data.cursor)
+    editor.remoteCursor = new RemoteCursorView(editor, data.cursor, data.userEmail)
     editor.scrollToBufferPosition(data.cursor, {center: true})
 
   sendFileEvents: (type , file) ->
@@ -96,6 +97,7 @@ class EventHandler
           data: {
             file: @project.relativize(editor.getPath()),
             cursor: event.newScreenPosition
+            userEmail: @userEmail
           }
         }
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -26,6 +26,10 @@ module.exports =
       title: 'Secure Connection'
       type: 'boolean'
       default: false
+    userEmail:
+      title: 'Email address'
+      type: 'string'
+      default: '(undefined)'
 
   setDefaultValues: ->
     @address = atom.config.get('motepair.serverAddress')

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -29,7 +29,7 @@ module.exports =
     userEmail:
       title: 'Email address'
       type: 'string'
-      default: '(undefined)'
+      default: ''
 
   setDefaultValues: ->
     @address = atom.config.get('motepair.serverAddress')

--- a/lib/remote-cursor-view.coffee
+++ b/lib/remote-cursor-view.coffee
@@ -1,9 +1,10 @@
 {Point} = require 'atom'
 {View} = require 'atom-space-pen-views'
+crypto = require 'crypto'
 
 class RemoteCursorView extends View
 
-  initialize: (@editor, position) ->
+  initialize: (@editor, position, userEmail) ->
     @marker = @editor.markBufferPosition Point.fromObject(position)
     @decoration = @editor.decorateMarker @marker,
       type: 'overlay',
@@ -15,6 +16,8 @@ class RemoteCursorView extends View
     @height @lineHeightInPixels
 
     @setCursorPosition(position)
+
+    @setGravatar(userEmail, Math.round(1.5*@lineHeightInPixels))
 
   setCursorPosition: (newPosition) ->
     position      = Point.fromObject(newPosition)
@@ -30,7 +33,14 @@ class RemoteCursorView extends View
 
     @marker.setHeadBufferPosition position
 
+  setGravatar: (email, size) ->
+    md5 = crypto.createHash('md5')
+    emailHash = md5.update(email).digest('hex')
+    @gravatar.attr src: "https://s.gravatar.com/avatar/#{emailHash}?s=#{size}"
+    @gravatar.attr alt: email
+
   @content: ->
-    @div class: 'mp-cursor'
+    @div class: 'mp-cursor', =>
+      @img class: 'mp-gravatar', outlet: 'gravatar'
 
 module.exports = RemoteCursorView

--- a/lib/remote-cursor-view.coffee
+++ b/lib/remote-cursor-view.coffee
@@ -34,10 +34,13 @@ class RemoteCursorView extends View
     @marker.setHeadBufferPosition position
 
   setGravatar: (email, size) ->
+    return unless email.length>0
+    
     md5 = crypto.createHash('md5')
     emailHash = md5.update(email).digest('hex')
     @gravatar.attr src: "https://s.gravatar.com/avatar/#{emailHash}?s=#{size}"
     @gravatar.attr alt: email
+    @gravatar.show()
 
   @content: ->
     @div class: 'mp-cursor', =>

--- a/styles/cursor.atom-text-editor.less
+++ b/styles/cursor.atom-text-editor.less
@@ -11,4 +11,5 @@
   transform: translate(-50%, -110%);
   border-radius: 50%;
   opacity: 0.5;
+  display: none;
 }

--- a/styles/cursor.atom-text-editor.less
+++ b/styles/cursor.atom-text-editor.less
@@ -5,3 +5,10 @@
   background: rgb(31, 161, 93);
   //transform: translate(0, -100%);
 }
+
+.mp-gravatar{
+  position: absolute;
+  transform: translate(-50%, -110%);
+  border-radius: 50%;
+  opacity: 0.5;
+}


### PR DESCRIPTION
This PR adds ability for users to input their email in package settings as requested here : https://github.com/motepair/motepair/issues/9

If they do, it enables "gravatar" feature which basically displays their gravatar as a bubble above their cursor on other user's editor. The design is very basic and would need some relifting / refactoring as it is probably not optimal for readability.

If user don't input his email, Gravatar is not used and the current behaviour is conserved (only cursor is visible).

Any user can input any email, and so on use any gravatar. Not sure if this should be considered as a "security issue".

There is another bug which is more annoying with gravatars because they take more space : when a user disconnects itself from the session, his cursors should be cleared on other users's editor.

I'm not really familiar with new Atom API, sorry in advance if any mistake / bad way of doing things.
