### PR TITLE
Multiproject and other fixes

### DIFF
--- a/coffeelint.json
+++ b/coffeelint.json
@@ -1,0 +1,135 @@
+{
+  "arrow_spacing": {
+    "level": "ignore"
+  },
+  "braces_spacing": {
+    "level": "ignore",
+    "spaces": 0,
+    "empty_object_spaces": 0
+  },
+  "camel_case_classes": {
+    "level": "error"
+  },
+  "coffeescript_error": {
+    "level": "error"
+  },
+  "colon_assignment_spacing": {
+    "level": "ignore",
+    "spacing": {
+      "left": 0,
+      "right": 0
+    }
+  },
+  "cyclomatic_complexity": {
+    "level": "ignore",
+    "value": 10
+  },
+  "duplicate_key": {
+    "level": "error"
+  },
+  "empty_constructor_needs_parens": {
+    "level": "ignore"
+  },
+  "ensure_comprehensions": {
+    "level": "warn"
+  },
+  "eol_last": {
+    "level": "ignore"
+  },
+  "indentation": {
+    "value": 2,
+    "level": "error"
+  },
+  "line_endings": {
+    "level": "ignore",
+    "value": "unix"
+  },
+  "max_line_length": {
+    "value": 200,
+    "level": "error",
+    "limitComments": true
+  },
+  "missing_fat_arrows": {
+    "level": "ignore",
+    "is_strict": false
+  },
+  "newlines_after_classes": {
+    "value": 3,
+    "level": "ignore"
+  },
+  "no_backticks": {
+    "level": "error"
+  },
+  "no_debugger": {
+    "level": "warn",
+    "console": false
+  },
+  "no_empty_functions": {
+    "level": "ignore"
+  },
+  "no_empty_param_list": {
+    "level": "ignore"
+  },
+  "no_implicit_braces": {
+    "level": "ignore",
+    "strict": true
+  },
+  "no_implicit_parens": {
+    "level": "ignore",
+    "strict": true
+  },
+  "no_interpolation_in_single_quotes": {
+    "level": "ignore"
+  },
+  "no_nested_string_interpolation": {
+    "level": "warn"
+  },
+  "no_plusplus": {
+    "level": "ignore"
+  },
+  "no_private_function_fat_arrows": {
+    "level": "warn"
+  },
+  "no_stand_alone_at": {
+    "level": "ignore"
+  },
+  "no_tabs": {
+    "level": "error"
+  },
+  "no_this": {
+    "level": "ignore"
+  },
+  "no_throwing_strings": {
+    "level": "error"
+  },
+  "no_trailing_semicolons": {
+    "level": "error"
+  },
+  "no_trailing_whitespace": {
+    "level": "error",
+    "allowed_in_comments": false,
+    "allowed_in_empty_lines": true
+  },
+  "no_unnecessary_double_quotes": {
+    "level": "ignore"
+  },
+  "no_unnecessary_fat_arrows": {
+    "level": "warn"
+  },
+  "non_empty_constructor_needs_parens": {
+    "level": "ignore"
+  },
+  "prefer_english_operator": {
+    "level": "ignore",
+    "doubleNotLevel": "ignore"
+  },
+  "space_operators": {
+    "level": "ignore"
+  },
+  "spacing_after_comma": {
+    "level": "ignore"
+  },
+  "transform_messes_up_line_numbers": {
+    "level": "warn"
+  }
+}

--- a/lib/event_handler.coffee
+++ b/lib/event_handler.coffee
@@ -39,8 +39,12 @@ class EventHandler
     , 300
 
   onsave: (data) ->
-    @workspace.getPaneItems().forEach (item) ->
-      item.save() if item.getPath? and item.getPath()?.indexOf(data.file) >= 0
+    @remoteAction = true
+    @workspace.getPaneItems().forEach (item) =>
+      item.save() if item.getPath? and item.getPath() is @locateFilePath(data)
+    setTimeout =>
+      @remoteAction = false
+    , 300
 
   onselect: (data) ->
     editor = atom.workspace.getActivePaneItem()

--- a/lib/event_handler.coffee
+++ b/lib/event_handler.coffee
@@ -165,7 +165,7 @@ class EventHandler
       @sendFileEvents('close', event.item.getPath())
 
     @subscriptions.add @workspace.onDidChangeActivePaneItem (event) =>
-      return unless event? and event.getPath? and event.getPath()? and event.getPath().match(new RegExp(@projectPath)) isnt null
+      return unless event? and event.getPath? and event.getPath()? and @locateProjectPath({ filePath: @project.relativizePath(event.getPath())}) isnt null
 
       @sendFileEvents('open', event.getPath())
 

--- a/lib/event_handler.coffee
+++ b/lib/event_handler.coffee
@@ -8,7 +8,6 @@ class EventHandler
   constructor: (@remoteClient) ->
     @emitter = new EventEmitter
     @project = atom.project
-    @projectPath = @project.getPaths()[0]
     @workspace = atom.workspace
     @subscriptions = new CompositeDisposable
     @localChange = false

--- a/lib/event_handler.coffee
+++ b/lib/event_handler.coffee
@@ -68,7 +68,7 @@ class EventHandler
 
     if now - @lastCursorChange < gravatarDelay
       clearInterval @gravatarTimeoutId
-    @gravatarTimeoutId = setTimeout =>
+    @gravatarTimeoutId = setTimeout ->
       editor.remoteCursor?.gravatar.hide(300)
     , gravatarDelay
 

--- a/lib/event_handler.coffee
+++ b/lib/event_handler.coffee
@@ -76,7 +76,14 @@ class EventHandler
 
 
   sendFileEvents: (type , file) ->
-    data = { a: 'meta', type: type, data: { file: @project.relativize(file) } }
+    data = {
+      a: 'meta',
+      type: type,
+      data: {
+        file: @project.relativize(file),
+        filePath: @project.relativizePath(file)
+      }
+    }
 
     unless @remoteAction
       @sendMessage data
@@ -106,6 +113,7 @@ class EventHandler
           type: 'cursor',
           data: {
             file: @project.relativize(editor.getPath()),
+            filePath: @project.relativizePath(editor.getPath()),
             cursor: event.newBufferPosition
             userEmail: @userEmail
           }
@@ -121,6 +129,7 @@ class EventHandler
           type: 'select',
           data: {
             file: @project.relativize(editor.getPath()),
+            filePath: @project.relativizePath(editor.getPath()),
             select: event.newBufferRange
           }
         }

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -99,8 +99,7 @@ module.exports =
     @ws.on 'error', (e) =>
       console.log('error', e)
       atom.notifications.addError("Motepair: Could not connect to server.")
-      @ws.close()
-      @ws = null
+      @deactivate()
 
 
   deactivate: ->

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -106,10 +106,10 @@ module.exports =
     clearInterval(@heartbeatId)
     if @ws?
       atom.notifications.addSuccess("Motepair: Disconnected from session.")
-      @sessionStatusView.hide()
+      @sessionStatusView.hide() if @sessionStatusView?
       @ws.close()
       @ws = null
-      @event_handler.subscriptions.dispose()
-      @atom_share.subscriptions.dispose()
+      @event_handler.subscriptions.dispose() if @event_handler?
+      @atom_share.subscriptions.dispose() if @atom_share?
     else
       atom.notifications.addWarning("Motepair: No active session found.")

--- a/lib/new-session-view.coffee
+++ b/lib/new-session-view.coffee
@@ -7,6 +7,7 @@ class NewSessionView extends View
 
   initialize: ->
     @miniEditor.setText(crypto.randomBytes(8).toString('hex'))
+    @miniEditor.getModel().selectAll()
     @miniEditor.focus()
 
     atom.commands.add '.new-session-view',


### PR DESCRIPTION
The main event : motepair now works with multiple projects open (#15). Client should remain backward compatible with older versions (single folder mode), but only newer versions will be able to cooperate in multi-project mode.

Also added a little polish and a bug fix.

---
- Adds coffeelint config
  - My first day doing any Coffeescript, and having a linter active is great feedback when you're learning by doing
  - Rather than disruptively beautify the file, I've widened the default max width from 80 cols
- Made a fix advised by coffeelint 
- Text in the new session ID dialog is now preselected
  - I found I was mousing the box to select the text and enter a custom ID
  - Now you can just type to replace it, or ctrl-C to copy it
- Call `deactivate` on error
  - I think the problem with #24 was being caused by the error routine not cleaning up everything
  - Also made the deactivate routine just make best effort about cleaning everything up
- Adds the results of `@project.relativizePath()` to the file metadata
  - This provides a project context to each relative filepath
- Add a routine that resolves project path
  - At the moment - it only matches on the name of the last folder in project path
  - I'm guessing this is good enough for 99% of use cases
- Since I had the server open in a terminal, observed that saving a file caused an infinite event cascade (all the clients would start playing save-the-file-event ping-pong)
  - Brought the save code in line with the other remote operations
- Changed the test for sending an event on file opening from "can we find this file in the first project" to "can we find this file in an open project"
  - Probably important to avoid opening arbitrary files :-)
